### PR TITLE
Add undocumented UNKN query type

### DIFF
--- a/sql_influx/main.py
+++ b/sql_influx/main.py
@@ -10,7 +10,7 @@ INFLUXDB_HOST = environ['INFLUXDB_HOST']
 INFLUXDB_PORT = environ['INFLUXDB_PORT']
 
 client = InfluxDBClient(host=INFLUXDB_HOST, port=INFLUXDB_PORT, database='pihole-FTL')
-types = ['A (IPv4)', 'AAAA (IPv6)', 'ANY', 'SRV', 'SOA', 'PTR', 'TXT']
+types = ['A (IPv4)', 'AAAA (IPv6)', 'ANY', 'SRV', 'SOA', 'PTR', 'TXT','','','','','','UNKN']
 statuses = ['Unknown', 'blocklist', 'localhost', 'cache', 'blocklist', 'blocklist', 'blocklist', 'blocklist',
             'blocklist', 'blocklist', 'blocklist', 'blocklist']
 


### PR DESCRIPTION
Hello Brandawg93

i faced an issue today the main.py script failed with the following:

`"type": types[item[2] - 1], IndexError: list index out of range`

In the pihole admin dashboard i managed to find an undocumented query type: "UNKN" with the id 13

I checked my pihole-FTL.db:

```SQL
/* sqlite3 /etc/pihole/pihole-FTL.db */
"SELECT DISTINCT type FROM queries;"
1
2
6
4
5
7
13
"SELECT count(type) FROM queries where id=13;"
1
```

Pi-Hole FTL Database query type: https://docs.pi-hole.net/database/ftl/#supported-query-types

The fix is not pretty but it works