### PR TITLE
Reduce cardinality of uniq tag

### DIFF
--- a/sql_influx/main.py
+++ b/sql_influx/main.py
@@ -63,7 +63,7 @@ def add_new_results(last_id):
                             {
                                 "measurement": "pihole-FTL",
                                 "tags": {
-                                    "uniq": item[0],
+                                    "uniq": item[0] % 1000,
                                     "type": types[item[2] - 1],
                                     "status": statuses[item[3]],
                                     "domain": item[4],


### PR DESCRIPTION
Storing the autoincrement id as a unique identifier/differentiator quickly
blows up the cardinality of the tag. Since it's an autoincrement, taking the
modulo of 1000 should be sufficient granularity to differentiate the datapoint
within the second long timestamp.

Followup to #16 and ed25ce7026287b2acfe24da3d097191dcef9ed0c