### PR TITLE
Parse timestamp as seconds since epoch instead of localtime

### DIFF
--- a/sql_influx/main.py
+++ b/sql_influx/main.py
@@ -70,7 +70,7 @@ def add_new_results(last_id):
                                     "client": item[5],
                                     "forward": item[6]
                                 },
-                                "time": time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime(item[1])),
+                                "time": time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime(item[1])),
                                 "fields": {
                                     "id": item[0]
                                 }


### PR DESCRIPTION
Timestamp for the FTL database are stored as a unix timestamp; therefore, if the system is set to a particular timezone, parsing as localtime results 
in the incorrect timestamp to be stored in InfluxDB.
